### PR TITLE
Better error reporting and use of jsonlint

### DIFF
--- a/bin/jjson.js
+++ b/bin/jjson.js
@@ -28,17 +28,61 @@ var opts = require("nomnom").option("file", {
 }).script("jjson").parse();
 
 var filename = opts.file;
-fs.readFile(filename, { encoding: opts.encoding }, function(err, json) {
+fs.readFile(filename, opts.encoding, function(err, json) {
     if(err) {
         return console.error("Error occurred while reading file: " + err.message);
     }
-
     var orig = json;
+    var jsonlint;
+    var error;
+    try {
+        // Test if jsonlint is installed
+        jsonlint = require("jsonlint");
+        // console.log('jsonlint loaded');
+
+        try {
+            var jsonlint_parser = require("jsonlint").parser;
+            // console.log('jsonlint parser loaded');
+            // Specify a compact output to open with Vim's 
+            // quickfix / location window to go directly to
+            // the line where the errors are.
+            jsonlint_parser.parseError = jsonlint_parser.lexer.parseError = function(str, hash) {
+                // console.error(filename + ': line '+ hash.loc.first_line +', col '+ hash.loc.last_column +', found: \''+ hash.token +'\' - expected: '+ hash.expected.join(', ') +'.');
+                //error = (filename + ': line '+ hash.loc.first_line +', col '+ hash.loc.last_column +', found: \''+ hash.token +'\' - expected: '+ hash.expected.join(', ') +'.');
+                error = (filename + ','+ hash.loc.first_line +','+ hash.loc.last_column +',found: \''+ hash.token +'\' - expected: '+ hash.expected.join(', ') +'.');
+                throw new Error(error);
+                //throw new Error(str);
+            };
+            //console.log('jsonlint parser parsed OK');
+            json = jsonlint_parser.parse(json);
+        } catch(e) {
+            // console.log('jsonlint parser output:'+json);
+            // console.log('jsonlint parser catch:'+e);
+            //if(opts["vim-plugin-mode"]) return console.log(orig);
+            //return console.error("Error occurred while parsing file: " + e.message);
+            //console.log(e.message);
+            console.log("Error occurred while parsing file: " + e.message);
+            process.exit(1);
+        }
+    }
+    catch( e ) {
+        if ( e.code === 'MODULE_NOT_FOUND' ) {
+            // The module hasn't been installed.
+            // Do not use jsonlint to validate the JSON
+            // before formatting it.
+            // console.log("\njsonlint is not installed");
+        }
+    }
+
     try {
         json = JSON.stringify(JSON.parse(json), true, opts.indent);
     } catch(e) {
-        if(opts["vim-plugin-mode"]) return console.log(orig);
-        return console.error("Error occurred while parsing file: " + e.message);
+        // console.log('JSON output:'+json);
+        // console.log('JSON catch:'+e);
+        //if(opts["vim-plugin-mode"]) return console.log(orig);
+        //console.error("Error occurred while parsing file: " + e.message + "\nJSON:" + JSON.stringify(json));
+        console.error("Error occurred while parsing file: " + e.message);
+        process.exit(1);
     }
 
     console.log(json);


### PR DESCRIPTION
The error messages received using JSON.stringify() are not very useful if there are errors in your JSON.

So, first check if the user has installed the npm package jsonlint.
If so, use it to verify the JSON.
It will report useful error messages, including error, line and column.

Pass these error messages back to the calling program (which in turn pumps this into Vim's location list feature so that you can click on the message and be taken to the correct line and column where the error is.

If the code passes the jsonlint test, then use JSON.stringify() to correctly format it.
